### PR TITLE
Continous deploy to Google Cloud Run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,39 @@ jobs:
       - name: Build Docker image
         run: docker build .
 
+  deploy_google_cloud_run:
+    # if: github.ref == 'refs/heads/master'
+    needs:
+      - build_docker_image
+      - golangci-lint
+      - program_starts
+      - tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+
+      - name: "GCP: Auth"
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS_JSON }}'
+
+      - name: "GCP: setup-gcloud"
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: neospring
+
+      - name: "GCP: gcloud info"
+        run: gcloud info
+
+      - name: "GCP: Publish image"
+        run: gcloud builds submit --tag gcr.io/neospring/neospring
+
+      - name: "GCP: Deploy neospring"
+        run: gcloud run deploy --image gcr.io/neospring/neospring --platform managed --region us-central1 neospring
+
   golangci-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/docs/gcp_service_account.md
+++ b/docs/gcp_service_account.md
@@ -1,0 +1,54 @@
+# GCP service account for building and deploying to Google Cloud Run
+
+I'd recommend not even trying to use the UI, which is awful. Instead, do things via CLI.
+
+Export some variables like name and project (project must exist already):
+
+    $ export SA_NAME="google-cloud-run-deploy-v4"
+    $ export PROJECT="neospring"
+
+Create a service account:
+
+    $ gcloud iam service-accounts create $SA_NAME --display-name=$SA_NAME --project $PROJECT --description="Used to deploy Google Cloud Run from passages-signup's GitHub Actions runs."
+
+Add necessary roles to the service account:
+
+    $ gcloud projects add-iam-policy-binding neospring --member="serviceAccount:$SA_NAME@$PROJECT.iam.gserviceaccount.com" --role="roles/cloudbuild.builds.builder"
+    $ gcloud projects add-iam-policy-binding neospring --member="serviceAccount:$SA_NAME@$PROJECT.iam.gserviceaccount.com" --role="roles/run.developer"
+    $ gcloud projects add-iam-policy-binding neospring --member="serviceAccount:$SA_NAME@$PROJECT.iam.gserviceaccount.com" --role="roles/run.serviceAgent"
+    $ gcloud projects add-iam-policy-binding neospring --member="serviceAccount:$SA_NAME@$PROJECT.iam.gserviceaccount.com" --role="roles/viewer"
+
+Create a service account JSON containing a secret:
+
+    $ gcloud iam service-accounts keys create service-account-key.json --iam-account=$SA_NAME@$PROJECT.iam.gserviceaccount.com
+
+Use the contents of `service-account-key.json` to put in the `GCP_CREDENTIALS_JSON` GitHub Actions secret for the build to work.
+
+## Debugging
+
+Dump a list of all roles to file:
+
+    $ gcloud iam roles list > all_roles
+
+Same thing, but just the role names for quick reference:
+
+    $ gcloud iam roles list | grep 'name: ' > all_roles
+
+Removing a role from a service account:
+
+    $ gcloud projects remove-iam-policy-binding neospring --member="serviceAccount:$SA_NAME@$PROJECT.iam.gserviceaccount.com" --role="roles/cloudbuild.serviceAgent"
+
+This error which is straight from hell is a problem wherein the CLI fails because it can't stream build output. Being inscrutable error messages and permissions caching that makes being sure of anything very difficult, _I believe_ the resolution was to add `roles/viewer`, but it's really hard to tell:
+
+    ERROR: (gcloud.builds.submit) 
+    The build is running, and logs are being written to the default logs bucket.
+    This tool can only stream logs if you are Viewer/Owner of the project and, if applicable, allowed by your VPC-SC security policy.
+
+A list of roles that I tried, but which didn't seem to be needed in the end with the matrix above:
+
+* `roles/cloudbuild.builds.editor`
+* `roles/cloudbuild.builds.viewer`
+* `roles/cloudbuild.serviceAgent`
+* `roles/iam.serviceAccountUser`
+* `roles/serviceusage.serviceUsageConsumer`
+* `run.admin`


### PR DESCRIPTION
Get continuous deploys to Google Cloud Run going so that the project has
somewhere stable to live.

Add a doc that roughly describes how to reproduce a working service
account, which is quite non-trivial.