### PR TITLE
Give the memory store a reap loop to regularly clean old boards out

### DIFF
--- a/internal/nsstore/nsmemstore/mem_store.go
+++ b/internal/nsstore/nsmemstore/mem_store.go
@@ -2,24 +2,34 @@ package nsmemstore
 
 import (
 	"context"
+	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/brandur/neospring/internal/nsstore"
 )
 
 type MemoryBoardStore struct {
-	boards  map[string]*nsstore.Board
-	timeNow func() time.Time
+	boards          map[string]*nsstore.Board
+	logger          *logrus.Logger
+	mut             sync.RWMutex
+	reapLoopStarted bool
+	timeNow         func() time.Time
 }
 
-func NewMemoryBoardStore() *MemoryBoardStore {
+func NewMemoryBoardStore(logger *logrus.Logger) *MemoryBoardStore {
 	return &MemoryBoardStore{
 		boards:  make(map[string]*nsstore.Board),
+		logger:  logger,
 		timeNow: time.Now,
 	}
 }
 
 func (s *MemoryBoardStore) Get(ctx context.Context, key string) (*nsstore.Board, error) {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
 	board, ok := s.boards[key]
 	if !ok {
 		return nil, nsstore.ErrKeyNotFound
@@ -35,6 +45,50 @@ func (s *MemoryBoardStore) Get(ctx context.Context, key string) (*nsstore.Board,
 }
 
 func (s *MemoryBoardStore) Put(ctx context.Context, key string, board *nsstore.Board) error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
 	s.boards[key] = board
 	return nil
+}
+
+func (s *MemoryBoardStore) ReapLoop(shutdown <-chan struct{}) {
+	if s.reapLoopStarted {
+		panic("ReapLoop already started -- should only be run once")
+	}
+
+	s.reapLoopStarted = true
+
+	for {
+		_ = s.reap()
+
+		select {
+		case <-shutdown:
+			s.logger.Infof("Received shutdown signal")
+			return
+
+		case <-time.After(10 * time.Second):
+		}
+	}
+}
+
+func (s *MemoryBoardStore) reap() int {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	now := s.timeNow()
+	var numReaped int
+
+	for key, board := range s.boards {
+		if now.After(board.Timestamp.Add(nsstore.MaxContentAge)) {
+			delete(s.boards, key)
+			numReaped++
+		}
+	}
+
+	s.logger.WithFields(logrus.Fields{
+		"num_reaped": numReaped,
+	}).Infof("Reaped %d board(s)", numReaped)
+
+	return numReaped
 }

--- a/internal/nsstore/nsmemstore/mem_store_test.go
+++ b/internal/nsstore/nsmemstore/mem_store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/brandur/neospring/internal/nskey"
@@ -17,27 +18,94 @@ const (
 	samplePublicKey  = "e90e9091b13a6e5194c1fed2728d1fdb6de7df362497d877b8c0b8f0883e1124"
 )
 
+var logger = logrus.New()
+
 func TestMemoryBoardStore(t *testing.T) {
 	ctx := context.Background()
 	keyPair := nskey.MustParseKeyPairUnchecked(samplePrivateKey)
-	store := NewMemoryBoardStore()
+	store := NewMemoryBoardStore(logger)
+	store.timeNow = func() time.Time { return stableTime }
 
-	_, err := store.Get(ctx, keyPair.PublicKey)
-	require.ErrorIs(t, nsstore.ErrKeyNotFound, err)
+	// Nothing stored initially.
+	{
+		_, err := store.Get(ctx, keyPair.PublicKey)
+		require.ErrorIs(t, nsstore.ErrKeyNotFound, err)
+	}
 
-	content := "some board content"
+	const content = "some board content"
 	board := &nsstore.Board{
 		Content:   []byte(content),
 		Signature: hex.EncodeToString(keyPair.Sign([]byte(content))),
 		Timestamp: stableTime,
 	}
-
-	err = store.Put(ctx, keyPair.PublicKey, board)
+	err := store.Put(ctx, keyPair.PublicKey, board)
 	require.NoError(t, err)
 
-	boardFromStore, err := store.Get(ctx, keyPair.PublicKey)
+	// After putting content, we now get the same content back.
+	{
+		boardFromStore, err := store.Get(ctx, keyPair.PublicKey)
+		require.NoError(t, err)
+		require.Equal(t, board, boardFromStore)
+	}
+
+	// When pushing time far into the future so that the content is after it's
+	// expiry, content is considered not present again.
+	{
+		store.timeNow = func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) }
+		_, err := store.Get(ctx, keyPair.PublicKey)
+		require.ErrorIs(t, nsstore.ErrKeyNotFound, err)
+	}
+}
+
+func TestMemoryBoardStoreReap(t *testing.T) {
+	ctx := context.Background()
+	keyPair := nskey.MustParseKeyPairUnchecked(samplePrivateKey)
+	store := NewMemoryBoardStore(logger)
+
+	const content = "some board content"
+	board := &nsstore.Board{
+		Content:   []byte(content),
+		Signature: hex.EncodeToString(keyPair.Sign([]byte(content))),
+		Timestamp: stableTime,
+	}
+	err := store.Put(ctx, keyPair.PublicKey, board)
 	require.NoError(t, err)
-	require.Equal(t, board, boardFromStore)
+	require.Len(t, store.boards, 1)
+
+	// Move into the future
+	store.timeNow = func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) }
+
+	numReaped := store.reap()
+	require.Equal(t, 1, numReaped)
+	require.Len(t, store.boards, 0)
+}
+
+func TestMemoryBoardStoreReapLoop(t *testing.T) {
+	ctx := context.Background()
+	keyPair := nskey.MustParseKeyPairUnchecked(samplePrivateKey)
+	store := NewMemoryBoardStore(logger)
+
+	const content = "some board content"
+	board := &nsstore.Board{
+		Content:   []byte(content),
+		Signature: hex.EncodeToString(keyPair.Sign([]byte(content))),
+		Timestamp: stableTime,
+	}
+	err := store.Put(ctx, keyPair.PublicKey, board)
+	require.NoError(t, err)
+	require.Len(t, store.boards, 1)
+
+	// Move into the future
+	store.timeNow = func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) }
+
+	shutdown := make(chan struct{}, 1)
+	close(shutdown)
+
+	// We pre-closed the shutdown channel, so this should run once, notice the
+	// shutdown, and exit.
+	store.ReapLoop(shutdown)
+
+	require.Len(t, store.boards, 0)
 }
 
 var stableTime = time.Date(2022, 11, 9, 10, 11, 12, 0, time.UTC)

--- a/server.go
+++ b/server.go
@@ -86,11 +86,11 @@ type Server struct {
 	timeNow     func() time.Time
 }
 
-func NewServer(boardStore nsstore.BoardStore, denyList DenyList, port int) *Server {
+func NewServer(logger *logrus.Logger, boardStore nsstore.BoardStore, denyList DenyList, port int) *Server {
 	server := &Server{
 		boardStore:  boardStore,
 		denyList:    denyList,
-		logger:      logrus.New(),
+		logger:      logger,
 		testKeyPair: nskey.MustParseKeyPairUnchecked(nskey.TestPrivateKey),
 		timeNow:     time.Now,
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
@@ -25,6 +26,8 @@ const (
 	samplePrivateKey = "90ba51828ecc30132d4707d55d24456fbd726514cf56ab4668b62392798e2540"
 	samplePublicKey  = "e90e9091b13a6e5194c1fed2728d1fdb6de7df362497d877b8c0b8f0883e1124"
 )
+
+var logger = logrus.New()
 
 // Since the various KeyPair parsing functions only take a private key portion,
 // this test case is here to make sure that the test/sample public keys we have
@@ -61,9 +64,9 @@ func TestServerHandleGetKey(t *testing.T) {
 			t.Helper()
 
 			ctx = context.Background()
-			store = nsmemstore.NewMemoryBoardStore()
+			store = nsmemstore.NewMemoryBoardStore(logger)
 			denyList = NewMemoryDenyList()
-			server = NewServer(store, denyList, defaultPort)
+			server = NewServer(logger, store, denyList, defaultPort)
 			server.timeNow = stableTimeFunc
 
 			test(t)
@@ -188,9 +191,9 @@ func TestServerHandlePutKey(t *testing.T) {
 			t.Helper()
 
 			ctx = context.Background()
-			store = nsmemstore.NewMemoryBoardStore()
+			store = nsmemstore.NewMemoryBoardStore(logger)
 			denyList = NewMemoryDenyList()
-			server = NewServer(store, denyList, defaultPort)
+			server = NewServer(logger, store, denyList, defaultPort)
 			server.timeNow = stableTimeFunc
 
 			test(t)
@@ -349,7 +352,7 @@ func TestServerWrapEndpoint(t *testing.T) {
 			ctxContainer = &ContextContainer{}
 			ctx = context.WithValue(ctx, contextContainerContextKey{}, ctxContainer)
 			recorder = httptest.NewRecorder()
-			server = NewServer(nil, nil, defaultPort)
+			server = NewServer(logger, nil, nil, defaultPort)
 
 			test(t)
 		}


### PR DESCRIPTION
Add a reap loop to the memory store that runs on a goroutine and
regularly cleans out expired boards.