### PR TITLE
Add internal memory store to GCP store

### DIFF
--- a/internal/nsstore/nsmemorystore/memory_store.go
+++ b/internal/nsstore/nsmemorystore/memory_store.go
@@ -56,6 +56,8 @@ func (s *MemoryStore) Put(ctx context.Context, key string, board *nsstore.Board)
 	return nil
 }
 
+// ReapLoop starts a reaper forever loop that periodically cleans up expired
+// keys. It blocks, so should be started on a goroutine.
 func (s *MemoryStore) ReapLoop(shutdown <-chan struct{}) {
 	if s.reapLoopStarted {
 		panic("ReapLoop already started -- should only be run once")
@@ -74,6 +76,11 @@ func (s *MemoryStore) ReapLoop(shutdown <-chan struct{}) {
 		case <-time.After(10 * time.Second):
 		}
 	}
+}
+
+// For testing purposes only.
+func (s *MemoryStore) SetTimeNow(timeNow func() time.Time) {
+	s.timeNow = timeNow
 }
 
 func (s *MemoryStore) reap() int {

--- a/internal/nsstore/nsmemorystore/memory_store_test.go
+++ b/internal/nsstore/nsmemorystore/memory_store_test.go
@@ -24,7 +24,7 @@ func TestMemoryBoardStore(t *testing.T) {
 	ctx := context.Background()
 	keyPair := nskey.MustParseKeyPairUnchecked(samplePrivateKey)
 	store := NewMemoryStore(logger)
-	store.timeNow = func() time.Time { return stableTime }
+	store.SetTimeNow(func() time.Time { return stableTime })
 
 	// Nothing stored initially.
 	{
@@ -51,7 +51,7 @@ func TestMemoryBoardStore(t *testing.T) {
 	// When pushing time far into the future so that the content is after it's
 	// expiry, content is considered not present again.
 	{
-		store.timeNow = func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) }
+		store.SetTimeNow(func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) })
 		_, err := store.Get(ctx, keyPair.PublicKey)
 		require.ErrorIs(t, nsstore.ErrKeyNotFound, err)
 	}
@@ -73,7 +73,7 @@ func TestMemoryBoardStoreReap(t *testing.T) {
 	require.Len(t, store.boards, 1)
 
 	// Move into the future
-	store.timeNow = func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) }
+	store.SetTimeNow(func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) })
 
 	numReaped := store.reap()
 	require.Equal(t, 1, numReaped)
@@ -96,7 +96,7 @@ func TestMemoryBoardStoreReapLoop(t *testing.T) {
 	require.Len(t, store.boards, 1)
 
 	// Move into the future
-	store.timeNow = func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) }
+	store.SetTimeNow(func() time.Time { return stableTime.Add(nsstore.MaxContentAge).Add(10 * time.Minute) })
 
 	shutdown := make(chan struct{}, 1)
 	close(shutdown)

--- a/main.go
+++ b/main.go
@@ -138,7 +138,9 @@ func runServe(ctx context.Context) error {
 	var store nsstore.BoardStore
 	switch {
 	case config.GCPStorageBucket != "":
-		store = nsgcpstoragestore.NewGCPStorageStore(ctx, logger, config.GCPCredentialsJSON, config.GCPStorageBucket)
+		gcpStore := nsgcpstoragestore.NewGCPStorageStore(ctx, logger, config.GCPCredentialsJSON, config.GCPStorageBucket)
+		go gcpStore.ReapLoop(shutdown)
+		store = gcpStore
 
 	default:
 		memoryStore := nsmemorystore.NewMemoryStore(logger)


### PR DESCRIPTION
Adds an internal memory store to the GCP store which can act as a cache
so that we don't have to go to slower GCP storage every time.