### PR TITLE
Make store reap loops part of the `nsstore.BoardStore` interface

### DIFF
--- a/internal/nsstore/nsgcpstoragestore/gcp_storage_store.go
+++ b/internal/nsstore/nsgcpstoragestore/gcp_storage_store.go
@@ -135,8 +135,8 @@ func (s *GCPStorageStore) SetTimeNow(timeNow func() time.Time) {
 //
 // Only reaps the struct's internal memory store rather than GCP itself, so a
 // delete lifetime policy still needs to be set on the GCP bucket in use.
-func (s *GCPStorageStore) ReapLoop(shutdown <-chan struct{}) {
-	s.memoryStore.ReapLoop(shutdown)
+func (s *GCPStorageStore) ReapLoop(ctx context.Context, shutdown <-chan struct{}) {
+	s.memoryStore.ReapLoop(ctx, shutdown)
 }
 
 // Very similar to `nsstore.Board`, but a specific serialized format stored to a

--- a/internal/nsstore/nsgcpstoragestore/gcp_storage_store_test.go
+++ b/internal/nsstore/nsgcpstoragestore/gcp_storage_store_test.go
@@ -144,7 +144,7 @@ func TestGCPStorageStoreReapLoop(t *testing.T) {
 
 	// We pre-closed the shutdown channel, so this should run once, notice the
 	// shutdown, and exit.
-	store.ReapLoop(shutdown)
+	store.ReapLoop(ctx, shutdown)
 }
 
 type readCloser struct {

--- a/internal/nsstore/nsmemorystore/memory_store.go
+++ b/internal/nsstore/nsmemorystore/memory_store.go
@@ -58,7 +58,7 @@ func (s *MemoryStore) Put(ctx context.Context, key string, board *nsstore.Board)
 
 // ReapLoop starts a reaper forever loop that periodically cleans up expired
 // keys. It blocks, so should be started on a goroutine.
-func (s *MemoryStore) ReapLoop(shutdown <-chan struct{}) {
+func (s *MemoryStore) ReapLoop(_ context.Context, shutdown <-chan struct{}) {
 	if s.reapLoopStarted {
 		panic("ReapLoop already started -- should only be run once")
 	}

--- a/internal/nsstore/nsmemorystore/memory_store_test.go
+++ b/internal/nsstore/nsmemorystore/memory_store_test.go
@@ -103,7 +103,7 @@ func TestMemoryBoardStoreReapLoop(t *testing.T) {
 
 	// We pre-closed the shutdown channel, so this should run once, notice the
 	// shutdown, and exit.
-	store.ReapLoop(shutdown)
+	store.ReapLoop(ctx, shutdown)
 
 	require.Len(t, store.boards, 0)
 }

--- a/internal/nsstore/store.go
+++ b/internal/nsstore/store.go
@@ -22,4 +22,10 @@ type Board struct {
 type BoardStore interface {
 	Get(ctx context.Context, key string) (*Board, error)
 	Put(ctx context.Context, key string, board *Board) error
+
+	// ReapLoop gives the store an opportunity to start a "reap loop" to help
+	// expire boards that are passed their maximum age. The function is called
+	// on a goroutine, so it's not necessary for implementations to start their
+	// own. Stores may no-op if they have an alternative expiration mechanism.
+	ReapLoop(ctx context.Context, shutdown <-chan struct{})
 }


### PR DESCRIPTION
Formalizes starting of reap loops as part of the board store interface
since both implementations have one anyway, and it lets us clean up main
code significantly.