### PR TITLE
Also set a stable time func for store in tests

### DIFF
--- a/internal/nsstore/nsgcpstoragestore/gcp_storage_store_test.go
+++ b/internal/nsstore/nsgcpstoragestore/gcp_storage_store_test.go
@@ -31,10 +31,18 @@ var sampleServiceAccountJSON string
 
 var stableTime = time.Date(2022, 11, 9, 10, 11, 12, 0, time.UTC)
 
+// For injecting a stable time into a server because eventually the sample key
+// we're using will expire, and if we were using `time.Now()`, that would start
+// failing all the tests.
+func stableTimeFunc() time.Time {
+	return stableTime
+}
+
 func TestGCPStorageStoreRead(t *testing.T) {
 	ctx := context.Background()
 	keyPair := nskey.MustParseKeyPairUnchecked(samplePrivateKey)
 	store := NewGCPStorageStore(ctx, logger, sampleServiceAccountJSON, "neospring_board")
+	store.SetTimeNow(stableTimeFunc)
 
 	store.storageReader = func(_ context.Context, bucket, key string) (io.ReadCloser, error) {
 		require.Equal(t, "neospring_board", bucket)
@@ -97,6 +105,7 @@ func TestGCPStorageStorePut(t *testing.T) {
 	ctx := context.Background()
 	keyPair := nskey.MustParseKeyPairUnchecked(samplePrivateKey)
 	store := NewGCPStorageStore(ctx, logger, sampleServiceAccountJSON, "neospring_board")
+	store.SetTimeNow(stableTimeFunc)
 
 	store.storageWriter = func(ctx context.Context, bucket, key string) io.WriteCloser {
 		require.Equal(t, "neospring_board", bucket)

--- a/server_test.go
+++ b/server_test.go
@@ -64,8 +64,12 @@ func TestServerHandleGetKey(t *testing.T) {
 			t.Helper()
 
 			ctx = context.Background()
+
 			store = nsmemorystore.NewMemoryStore(logger)
+			store.SetTimeNow(stableTimeFunc)
+
 			denyList = NewMemoryDenyList()
+
 			server = NewServer(logger, store, denyList, defaultPort)
 			server.timeNow = stableTimeFunc
 
@@ -191,8 +195,12 @@ func TestServerHandlePutKey(t *testing.T) {
 			t.Helper()
 
 			ctx = context.Background()
+
 			store = nsmemorystore.NewMemoryStore(logger)
+			store.SetTimeNow(stableTimeFunc)
+
 			denyList = NewMemoryDenyList()
+
 			server = NewServer(logger, store, denyList, defaultPort)
 			server.timeNow = stableTimeFunc
 
@@ -353,7 +361,9 @@ func TestServerRouter(t *testing.T) {
 	ctx := context.Background()
 	denyList := NewMemoryDenyList()
 	keyPair := nskey.MustParseKeyPairUnchecked(samplePrivateKey)
+
 	store := nsmemorystore.NewMemoryStore(logger)
+	store.SetTimeNow(stableTimeFunc)
 
 	server := NewServer(logger, store, denyList, defaultPort)
 	server.timeNow = stableTimeFunc


### PR DESCRIPTION
The test suite is currently failing because although we'd accounted for
eventual board expiry at our stable time function in the test server, we
weren't pushing a stable time down into the store, so it was using the
real clock and immediately considering stored content invalid as it
had passed 22 days in age.

Here, also inject stable time into the test store to fix the problem.